### PR TITLE
Enable Hackage friendly stack.yaml settings

### DIFF
--- a/refresht.cabal
+++ b/refresht.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Control.Monad.Refresh
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.8 && < 5
                      , mtl
                      , data-default
                      , lens

--- a/stack.yaml
+++ b/stack.yaml
@@ -64,3 +64,4 @@ extra-package-dbs: []
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+pvp-bounds: both


### PR DESCRIPTION
This also changes the lower bound on `base` as this package
currently needs at least GHC 7.10 / base-4.8 to compile.

See also https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds